### PR TITLE
Refactor .js files into modules

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -55,10 +55,10 @@
         </article>
     </main>
 
-    <script src="scripts/data.js"></script>
-    <script src="scripts/entryList.js"></script>
-    <script src="scripts/entryComponent.js"></script>
-    <script src="scripts/journal.js"></script>
+    <!-- <script src="scripts/data.js"></script> -->
+    <!-- <script type="module" src="scripts/entryList.js"></script> -->
+    <!-- <script src="scripts/entryComponent.js"></script> -->
+    <script type="module" src="scripts/journal.js"></script>
 
 </body>
 </html>

--- a/src/scripts/data.js
+++ b/src/scripts/data.js
@@ -4,8 +4,10 @@
 */
 
 const API = {
-    getJournalEntries () {
+    getJournalEntries() {
         return fetch("http://localhost:8088/entries")
             .then(response => response.json())
     }
 }
+
+export default API

--- a/src/scripts/entryComponent.js
+++ b/src/scripts/entryComponent.js
@@ -10,3 +10,5 @@ const journalHTML = {
                     </section>`
     }
 }
+
+export default journalHTML

--- a/src/scripts/entryList.js
+++ b/src/scripts/entryList.js
@@ -1,3 +1,5 @@
+import journalHTML from "./entryComponent.js"
+
 /*
     Purpose: To render all journal entries to the DOM
 
@@ -6,11 +8,12 @@
 
 const journalList = {
     renderJournalEntries (entries) {
-                // const insertionPoint = document.querySelector(".entryLog")
 
-                for (entry of entries) {
-                    entryHTML = journalHTML.makeJournalEntryComponent(entry)
+                for (const entry of entries) {
+                    const entryHTML = journalHTML.makeJournalEntryComponent(entry)
                     document.querySelector(".entryLog").innerHTML += entryHTML
                 }
     }
 }
+
+export default journalList

--- a/src/scripts/journal.js
+++ b/src/scripts/journal.js
@@ -3,4 +3,7 @@
     defined in the other JavaScript files
 */
 
+import API from "./data.js"
+import journalList from "./entryList.js"
+
 API.getJournalEntries().then(entryArray => journalList.renderJournalEntries(entryArray))


### PR DESCRIPTION
Refactored index to include only one script tag, and to use remaining .js files as import modules.

No changes have been made from the user's perspective.